### PR TITLE
Add a startOffset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Create a new readable stream. Options include:
 
 ``` js
 {
-  tail: false // keep reading the fd forever (will pool it)
-  retry: 0 // wait this many ms and retry a read once if it fails
+  tail: false, // keep reading the fd forever (will pool it)
+  retry: 0, // wait this many ms and retry a read once if it fails
+  startOffset: 0 // byte offset to start reading from.
 }
 ```
 

--- a/example.js
+++ b/example.js
@@ -1,6 +1,8 @@
 var fs = require('fs')
 var read = require('./')
 
-var rs = read(fs.openSync(__filename, 'r'), {retry: 100})
+var rs = read(fs.openSync(__filename, 'r'), {retry: 100, startOffset: 0})
 
-rs.on('data', console.log)
+rs.on('data', function (buf) {
+  console.log(buf.toString())
+})

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function ReadStream (fd, opts) {
   stream.Readable.call(this, {highWaterMark: opts.highWaterMark || 65536})
 
   this.fd = fd
-  this.bytesRead = 0
+  this.bytesRead = opts.startOffset || 0
   this.destroyed = false
 
   this._retry = opts.retry || 0


### PR DESCRIPTION
Allows reading to begin anywhere in the file. I want this so
I can resuming tailing a file from a saved point,
and consume data that has been added while the process
was stopped.